### PR TITLE
Improve Firefox compatibility + various fixes

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`neh should handle "1+1" correctly 1`] = `
+exports[`neh should handle "1%20+%201" "%20"-spaced query correctly 1`] = `
 Response {
   "body": null,
   "bodyUsed": false,
   "headers": Headers {
     "_map": Map {
-      "location" => "https://duckduckgo.com/?q=1%2B1",
+      "location" => "https://duckduckgo.com/?q=1+%2B+1",
     },
   },
   "method": "GET",
@@ -19,13 +19,13 @@ Response {
 }
 `;
 
-exports[`neh should handle "drive 2" correctly 1`] = `
+exports[`neh should handle "1+%2B+1" "+"-spaced query correctly 1`] = `
 Response {
   "body": null,
   "bodyUsed": false,
   "headers": Headers {
     "_map": Map {
-      "location" => "https://drive.google.com/drive/u/2/",
+      "location" => "https://duckduckgo.com/?q=1+%2B+1",
     },
   },
   "method": "GET",
@@ -38,7 +38,7 @@ Response {
 }
 `;
 
-exports[`neh should handle "drive" correctly 1`] = `
+exports[`neh should handle "drive" "%20"-spaced query correctly 1`] = `
 Response {
   "body": null,
   "bodyUsed": false,
@@ -57,7 +57,64 @@ Response {
 }
 `;
 
-exports[`neh should handle "ip" correctly 1`] = `
+exports[`neh should handle "drive" "+"-spaced query correctly 1`] = `
+Response {
+  "body": null,
+  "bodyUsed": false,
+  "headers": Headers {
+    "_map": Map {
+      "location" => "https://drive.google.com",
+    },
+  },
+  "method": "GET",
+  "ok": false,
+  "redirected": false,
+  "status": 302,
+  "statusText": "OK",
+  "type": "basic",
+  "url": "http://example.com/asset",
+}
+`;
+
+exports[`neh should handle "drive%202" "%20"-spaced query correctly 1`] = `
+Response {
+  "body": null,
+  "bodyUsed": false,
+  "headers": Headers {
+    "_map": Map {
+      "location" => "https://drive.google.com/drive/u/2/",
+    },
+  },
+  "method": "GET",
+  "ok": false,
+  "redirected": false,
+  "status": 302,
+  "statusText": "OK",
+  "type": "basic",
+  "url": "http://example.com/asset",
+}
+`;
+
+exports[`neh should handle "drive+2" "+"-spaced query correctly 1`] = `
+Response {
+  "body": null,
+  "bodyUsed": false,
+  "headers": Headers {
+    "_map": Map {
+      "location" => "https://drive.google.com/drive/u/2/",
+    },
+  },
+  "method": "GET",
+  "ok": false,
+  "redirected": false,
+  "status": 302,
+  "statusText": "OK",
+  "type": "basic",
+  "url": "http://example.com/asset",
+}
+`;
+
+exports[`neh should handle "ip" "%20"-spaced query correctly 1`] = `
 Response {
   "body": null,
   "bodyUsed": false,
@@ -76,7 +133,26 @@ Response {
 }
 `;
 
-exports[`neh should handle "lyrics here's to never growing up" correctly 1`] = `
+exports[`neh should handle "ip" "+"-spaced query correctly 1`] = `
+Response {
+  "body": null,
+  "bodyUsed": false,
+  "headers": Headers {
+    "_map": Map {
+      "location" => "https://icanhazip.com",
+    },
+  },
+  "method": "GET",
+  "ok": false,
+  "redirected": false,
+  "status": 302,
+  "statusText": "OK",
+  "type": "basic",
+  "url": "http://example.com/asset",
+}
+`;
+
+exports[`neh should handle "lyrics%20here's%20to%20never%20growing%20up" "%20"-spaced query correctly 1`] = `
 Response {
   "body": null,
   "bodyUsed": false,
@@ -95,7 +171,26 @@ Response {
 }
 `;
 
-exports[`neh should handle "npm p @babel/core" correctly 1`] = `
+exports[`neh should handle "lyrics+here's+to+never+growing+up" "+"-spaced query correctly 1`] = `
+Response {
+  "body": null,
+  "bodyUsed": false,
+  "headers": Headers {
+    "_map": Map {
+      "location" => "https://duckduckgo.com/?q=%5Csite:genius.com%20here's%20to%20never%20growing%20up",
+    },
+  },
+  "method": "GET",
+  "ok": false,
+  "redirected": false,
+  "status": 302,
+  "statusText": "OK",
+  "type": "basic",
+  "url": "http://example.com/asset",
+}
+`;
+
+exports[`neh should handle "npm%20p%20@babel/core" "%20"-spaced query correctly 1`] = `
 Response {
   "body": null,
   "bodyUsed": false,
@@ -114,7 +209,26 @@ Response {
 }
 `;
 
-exports[`neh should handle "search query" correctly 1`] = `
+exports[`neh should handle "npm+p+@babel/core" "+"-spaced query correctly 1`] = `
+Response {
+  "body": null,
+  "bodyUsed": false,
+  "headers": Headers {
+    "_map": Map {
+      "location" => "https://www.npmjs.com/package/@babel/core",
+    },
+  },
+  "method": "GET",
+  "ok": false,
+  "redirected": false,
+  "status": 302,
+  "statusText": "OK",
+  "type": "basic",
+  "url": "http://example.com/asset",
+}
+`;
+
+exports[`neh should handle "search%20query" "%20"-spaced query correctly 1`] = `
 Response {
   "body": null,
   "bodyUsed": false,
@@ -133,7 +247,45 @@ Response {
 }
 `;
 
-exports[`neh should handle "trzh hong kong" correctly 1`] = `
+exports[`neh should handle "search+query" "+"-spaced query correctly 1`] = `
+Response {
+  "body": null,
+  "bodyUsed": false,
+  "headers": Headers {
+    "_map": Map {
+      "location" => "https://duckduckgo.com/?q=search+query",
+    },
+  },
+  "method": "GET",
+  "ok": false,
+  "redirected": false,
+  "status": 302,
+  "statusText": "OK",
+  "type": "basic",
+  "url": "http://example.com/asset",
+}
+`;
+
+exports[`neh should handle "trzh%20hong%20kong" "%20"-spaced query correctly 1`] = `
+Response {
+  "body": null,
+  "bodyUsed": false,
+  "headers": Headers {
+    "_map": Map {
+      "location" => "https://fanyi.baidu.com/#en/zh/hong%20kong",
+    },
+  },
+  "method": "GET",
+  "ok": false,
+  "redirected": false,
+  "status": 302,
+  "statusText": "OK",
+  "type": "basic",
+  "url": "http://example.com/asset",
+}
+`;
+
+exports[`neh should handle "trzh+hong+kong" "+"-spaced query correctly 1`] = `
 Response {
   "body": null,
   "bodyUsed": false,

--- a/src/handlers/list/template.pug
+++ b/src/handlers/list/template.pug
@@ -1,5 +1,5 @@
 mixin docTable(doc, nested)
-  table.text-left.w-full.sm_px-4.nested.h-full(class='" + ? "" : "')
+  table.text-left.w-full.sm_px-4.nested(class=nested ? "" : " h-full")
     thead.uppercase.text-xs.text-gray-700.tracking-wide
       tr
         th.p-3 Command

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,8 +3,17 @@ declare const self: CloudflareWorkerGlobalScope;
 
 import { makeCloudflareWorkerRequest } from 'cloudflare-worker-mock';
 
-async function getResponse(path: string): Promise<Response> {
-  const request = makeCloudflareWorkerRequest(path);
+async function getResponse(requestInfo: RequestInfo): Promise<Response> {
+  const request = makeCloudflareWorkerRequest(requestInfo);
+  // userAgent
+  //   ? path
+  //   : new Request(path, {
+  //       headers: {
+  //         'User-Agent':
+  //           'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:85.0) Gecko/20100101 Firefox/85.0',
+  //       },
+  //     }),
+  // );
   return await self.trigger('fetch', request);
 }
 
@@ -29,7 +38,7 @@ describe('neh', () => {
 
   // Some test input
   const testCases = [
-    '1+1',
+    '1 + 1',
     'drive 2',
     'drive',
     'ip',
@@ -39,10 +48,28 @@ describe('neh', () => {
     'trzh hong kong',
   ];
 
-  testCases.forEach((inputStr) => {
-    test(`should handle "${inputStr}" correctly`, async () => {
-      const response = await getResponse(inputStr);
-      expect(response).toMatchSnapshot();
+  testCases
+    .map((inputStr) => inputStr.replace(/ /g, '%20'))
+    .forEach((inputStr) => {
+      test(`should handle "${inputStr}" "%20"-spaced query correctly`, async () => {
+        const response = await getResponse(inputStr);
+        expect(response).toMatchSnapshot();
+      });
     });
-  });
+
+  testCases
+    .map((inputStr) => inputStr.replace(/\+/g, '%2B').replace(/ /g, '+'))
+    .forEach((inputStr) => {
+      test(`should handle "${inputStr}" "+"-spaced query correctly`, async () => {
+        const response = await getResponse(
+          new Request(inputStr, {
+            headers: {
+              'User-Agent':
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:85.0) Gecko/20100101 Firefox/85.0',
+            },
+          }),
+        );
+        expect(response).toMatchSnapshot();
+      });
+    });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -5,15 +5,6 @@ import { makeCloudflareWorkerRequest } from 'cloudflare-worker-mock';
 
 async function getResponse(requestInfo: RequestInfo): Promise<Response> {
   const request = makeCloudflareWorkerRequest(requestInfo);
-  // userAgent
-  //   ? path
-  //   : new Request(path, {
-  //       headers: {
-  //         'User-Agent':
-  //           'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:85.0) Gecko/20100101 Firefox/85.0',
-  //       },
-  //     }),
-  // );
   return await self.trigger('fetch', request);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,10 @@ async function handleRequest(request: Request): Promise<Response> {
     });
   }
 
-  const isFirefox = /\bFirefox\b/i.test(request.headers.get('user-agent') || '');
-  const query = extractQueryFromUrl(request.url, isFirefox);
+  // extractQueryFromUrl explains why areSpacesEncodedAsPlus is necessary
+  const areSpacesEncodedAsPlus = /\bFirefox\b/i.test(request.headers.get('user-agent') || '');
+  const query = extractQueryFromUrl(request.url, areSpacesEncodedAsPlus);
+
   const tokens = tokenizeQuery(query);
   return await handler.handle(tokens);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ async function handleRequest(request: Request): Promise<Response> {
   if (requestURL.pathname === '/_opensearch') {
     return new Response(openSearchDescription, {
       headers: {
-        'content-type': 'application/xml',
+        'content-type': 'application/opensearchdescription+xml',
       },
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,8 @@ async function handleRequest(request: Request): Promise<Response> {
     });
   }
 
-  const query = extractQueryFromUrl(request.url);
+  const isFirefox = /\bFirefox\b/i.test(request.headers.get('user-agent') || '');
+  const query = extractQueryFromUrl(request.url, isFirefox);
   const tokens = tokenizeQuery(query);
   return await handler.handle(tokens);
 }

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -35,6 +35,22 @@ describe(extractQueryFromUrl, () => {
       'cmd https://derp.com/search#query',
     );
   });
+
+  test('should accept queries encoded with `+` instead of `%20` for space characters', () => {
+    expect(extractQueryFromUrl('https://example.com/cmd+token', true)).toEqual('cmd token');
+
+    expect(extractQueryFromUrl('https://example.com/cmd+https://derp.com', true)).toEqual(
+      'cmd https://derp.com',
+    );
+
+    expect(
+      extractQueryFromUrl('https://example.com/cmd+https://derp.com/search?q=query', true),
+    ).toEqual('cmd https://derp.com/search?q=query');
+
+    expect(
+      extractQueryFromUrl('https://example.com/cmd+https://derp.com/search#query', true),
+    ).toEqual('cmd https://derp.com/search#query');
+  });
 });
 
 describe(tokenizeQuery, () => {

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -16,28 +16,14 @@ describe(emptyArray, () => {
 
 describe(extractQueryFromUrl, () => {
   test('should return empty string if no query', () => {
-    expect(extractQueryFromUrl('https://example.com')).toEqual('');
-    expect(extractQueryFromUrl('https://example.com/')).toEqual('');
+    expect(extractQueryFromUrl('https://example.com', false)).toEqual('');
+    expect(extractQueryFromUrl('https://example.com/', false)).toEqual('');
   });
 
-  test('should return query from path if present', () => {
-    expect(extractQueryFromUrl('https://example.com/cmd%20token')).toEqual('cmd token');
-
-    expect(extractQueryFromUrl('https://example.com/cmd%20https://derp.com')).toEqual(
-      'cmd https://derp.com',
-    );
-
-    expect(
-      extractQueryFromUrl('https://example.com/cmd%20https://derp.com/search?q=query'),
-    ).toEqual('cmd https://derp.com/search?q=query');
-
-    expect(extractQueryFromUrl('https://example.com/cmd%20https://derp.com/search#query')).toEqual(
-      'cmd https://derp.com/search#query',
-    );
-  });
-
-  test('should accept queries encoded with `+` instead of `%20` for space characters', () => {
+  test('should return query-encoded query from path if present', () => {
     expect(extractQueryFromUrl('https://example.com/cmd+token', true)).toEqual('cmd token');
+
+    expect(extractQueryFromUrl('https://example.com/d+1%2B2', true)).toEqual('d 1+2');
 
     expect(extractQueryFromUrl('https://example.com/cmd+https://derp.com', true)).toEqual(
       'cmd https://derp.com',
@@ -49,6 +35,24 @@ describe(extractQueryFromUrl, () => {
 
     expect(
       extractQueryFromUrl('https://example.com/cmd+https://derp.com/search#query', true),
+    ).toEqual('cmd https://derp.com/search#query');
+  });
+
+  test('should return path-encoded query from path if present', () => {
+    expect(extractQueryFromUrl('https://example.com/cmd%20token', false)).toEqual('cmd token');
+
+    expect(extractQueryFromUrl('https://example.com/d%201+2', false)).toEqual('d 1+2');
+
+    expect(extractQueryFromUrl('https://example.com/cmd%20https://derp.com', false)).toEqual(
+      'cmd https://derp.com',
+    );
+
+    expect(
+      extractQueryFromUrl('https://example.com/cmd%20https://derp.com/search?q=query', false),
+    ).toEqual('cmd https://derp.com/search?q=query');
+
+    expect(
+      extractQueryFromUrl('https://example.com/cmd%20https://derp.com/search#query', false),
     ).toEqual('cmd https://derp.com/search#query');
   });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,7 +6,14 @@ export function emptyArray<T>(arr: T[]): void {
   arr.splice(0, arr.length);
 }
 
-export function extractQueryFromUrl(urlStr: string): string {
+export function extractQueryFromUrl(urlStr: string, convertPlusToSpace?: boolean): string {
+  // Firefox sends search queries for 'token1 token2' as '/token1+token2',
+  // while Chrome sends '/token1%20token2'. The `convertPlusToSpace` normalizes
+  // this behaviour.
+  if (convertPlusToSpace) {
+    urlStr = urlStr.replace(/\+/g, '%20');
+  }
+
   // Use url-parse instead of URL for pathname as double slashes will be
   // removed on Cloudflare by URL.
   const parsedUrl = parse(urlStr, true);

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,19 +6,20 @@ export function emptyArray<T>(arr: T[]): void {
   arr.splice(0, arr.length);
 }
 
-export function extractQueryFromUrl(urlStr: string, convertPlusToSpace?: boolean): string {
-  // Firefox sends search queries for 'token1 token2' as '/token1+token2',
-  // while Chrome sends '/token1%20token2'. The `convertPlusToSpace` normalizes
-  // this behaviour.
-  if (convertPlusToSpace) {
-    urlStr = urlStr.replace(/\+/g, '%20');
-  }
-
+export function extractQueryFromUrl(urlStr: string, areSpacesEncodedAsPlus: boolean): string {
   // Use url-parse instead of URL for pathname as double slashes will be
   // removed on Cloudflare by URL.
   const parsedUrl = parse(urlStr, true);
+
+  // Browsers encode the query in 2 ways:
+  // 1. Query, e.g. "token1+%2B+token2". Firefox does this.
+  // 2. Path, e.g. "token1%20+%20token2". Chrome does this.
+  const pathname = areSpacesEncodedAsPlus
+    ? parsedUrl.pathname.replace(/\+/g, ' ')
+    : parsedUrl.pathname;
+
   const url = new URL(urlStr);
-  let query = decodeURIComponent(parsedUrl.pathname + url.search + url.hash);
+  let query = decodeURIComponent(pathname + url.search + url.hash);
   if (query.charAt(0) === '/') {
     query = query.substring(1);
   }


### PR DESCRIPTION
- `/_opensearch`: send correct MIME type
- `/list`: fix wrong classes
  Seems like `yarn lint:fix` in commit f0dd1aa distorted the original code.
- Fix search queries in Firefox
  Firefox encodes it URLs differently from Chrome, so I used a regular expression to detect Firefox user-agents, and perform some pre-processing of the URL string (converting "+" to "%20") for consistency with Chrome. Not sure if this is the best solution, but it is what it is.
  I've done some preliminary testing and it seems like this solution doesn't affect the search engine in Chrome, and allows for expected behaviour in Firefox. Not really sure which URL encoding is correct actually.