### PR TITLE
feat: add pf (Paraform) and gp (Graphite) commands; remove old commands

### DIFF
--- a/src/handlers/gh.test.ts
+++ b/src/handlers/gh.test.ts
@@ -22,7 +22,6 @@ describe('gh handler', () => {
     });
   });
 
-
   describe('p handler', () => {
     test('should redirect if at least one user is returned', async () => {
       fetchMock.enableMocks();

--- a/src/handlers/gh.test.ts
+++ b/src/handlers/gh.test.ts
@@ -2,6 +2,27 @@ import fetchMock from 'jest-fetch-mock';
 import handler from './gh';
 
 describe('gh handler', () => {
+  describe('default handler', () => {
+    test('should convert a Graphite PR URL to a GitHub PR URL', async () => {
+      const response = await handler.handle([
+        'https://app.graphite.com/github/pr/paraform-xyz/paraform/10437',
+      ]);
+      expect(response.status).toBe(302);
+      expect(response.headers.get('location')).toMatchInlineSnapshot(
+        `"https://github.com/paraform-xyz/paraform/pull/10437"`,
+      );
+    });
+
+    test('should do a GitHub search for non-Graphite tokens', async () => {
+      const response = await handler.handle(['react', 'hooks']);
+      expect(response.status).toBe(302);
+      expect(response.headers.get('location')).toMatchInlineSnapshot(
+        `"https://github.com/search?q=react+hooks"`,
+      );
+    });
+  });
+
+
   describe('p handler', () => {
     test('should redirect if at least one user is returned', async () => {
       fetchMock.enableMocks();

--- a/src/handlers/gh.ts
+++ b/src/handlers/gh.ts
@@ -1,5 +1,9 @@
 import { CommandHandler, FunctionHandler, RedirectHandler, HandlerFn } from '../Handler';
-import { SearchEngineHandler, makeParamBasedSearchEngine } from '../SearchEngineHandler';
+import {
+  SearchEngineHandler,
+  makeParamBasedSearchEngine,
+  SearchEngine,
+} from '../SearchEngineHandler';
 import { redirect } from '../util';
 
 const gh = new CommandHandler();
@@ -7,10 +11,29 @@ const ghHomeUrl = 'https://github.com/';
 
 gh.setNothingHandler(new RedirectHandler('navigates to GitHub', ghHomeUrl));
 
+const githubSearchEngine = makeParamBasedSearchEngine(ghHomeUrl, 'https://github.com/search', 'q');
+
+const ghDefaultSearchEngine: SearchEngine = {
+  ...githubSearchEngine,
+  generateSearchUrl(tokens): string {
+    if (tokens.length > 0) {
+      // https://app.graphite.com/github/pr/{owner}/{repo}/{number}
+      const graphiteMatch = tokens[0].match(
+        /^https:\/\/app\.graphite\.com\/github\/pr\/([^/]+)\/([^/]+)\/(\d+)/,
+      );
+      if (graphiteMatch) {
+        const [, owner, repo, prNumber] = graphiteMatch;
+        return `https://github.com/${owner}/${repo}/pull/${prNumber}`;
+      }
+    }
+    return githubSearchEngine.generateSearchUrl(tokens);
+  },
+};
+
 gh.setDefaultHandler(
   new SearchEngineHandler(
-    'does a GitHub search',
-    makeParamBasedSearchEngine(ghHomeUrl, 'https://github.com/search', 'q'),
+    'does a GitHub search, or converts a Graphite PR URL to a GitHub PR URL',
+    ghDefaultSearchEngine,
   ),
 );
 

--- a/src/handlers/gp.test.ts
+++ b/src/handlers/gp.test.ts
@@ -1,0 +1,29 @@
+import gpHandler from './gp';
+
+describe('gp handler', () => {
+  test('should redirect to Graphite home if no tokens provided', async () => {
+    const response = await gpHandler.handle([]);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toMatchInlineSnapshot(
+      `"https://app.graphite.com/"`,
+    );
+  });
+
+  test('should convert a GitHub PR URL to a Graphite PR URL', async () => {
+    const response = await gpHandler.handle([
+      'https://github.com/paraform-xyz/paraform/pull/10437',
+    ]);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toMatchInlineSnapshot(
+      `"https://app.graphite.com/github/pr/paraform-xyz/paraform/10437"`,
+    );
+  });
+
+  test('should redirect to Graphite home if token is not a GitHub PR URL', async () => {
+    const response = await gpHandler.handle(['some random text']);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toMatchInlineSnapshot(
+      `"https://app.graphite.com/"`,
+    );
+  });
+});

--- a/src/handlers/gp.test.ts
+++ b/src/handlers/gp.test.ts
@@ -4,9 +4,7 @@ describe('gp handler', () => {
   test('should redirect to Graphite home if no tokens provided', async () => {
     const response = await gpHandler.handle([]);
     expect(response.status).toBe(302);
-    expect(response.headers.get('location')).toMatchInlineSnapshot(
-      `"https://app.graphite.com/"`,
-    );
+    expect(response.headers.get('location')).toMatchInlineSnapshot(`"https://app.graphite.com/"`);
   });
 
   test('should convert a GitHub PR URL to a Graphite PR URL', async () => {
@@ -22,8 +20,6 @@ describe('gp handler', () => {
   test('should redirect to Graphite home if token is not a GitHub PR URL', async () => {
     const response = await gpHandler.handle(['some random text']);
     expect(response.status).toBe(302);
-    expect(response.headers.get('location')).toMatchInlineSnapshot(
-      `"https://app.graphite.com/"`,
-    );
+    expect(response.headers.get('location')).toMatchInlineSnapshot(`"https://app.graphite.com/"`);
   });
 });

--- a/src/handlers/gp.ts
+++ b/src/handlers/gp.ts
@@ -1,0 +1,22 @@
+import { FunctionHandler } from '../Handler';
+import { redirect } from '../util';
+
+const graphiteHomeUrl = 'https://app.graphite.com/';
+
+const gp = new FunctionHandler(
+  'navigates to Graphite, or converts a GitHub PR URL to a Graphite PR URL',
+  (tokens) => {
+    if (tokens && tokens.length > 0) {
+      const firstToken = tokens[0];
+      // https://github.com/{owner}/{repo}/pull/{number}
+      const ghPrMatch = firstToken.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+      if (ghPrMatch) {
+        const [, owner, repo, prNumber] = ghPrMatch;
+        return redirect(`https://app.graphite.com/github/pr/${owner}/${repo}/${prNumber}`);
+      }
+    }
+    return redirect(graphiteHomeUrl);
+  },
+);
+
+export default gp;

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -11,10 +11,9 @@ import dictHandler from './dict';
 import docsHandler from './docs';
 import ghHandler from './gh';
 import glHandler from './gl';
-import ibankHandler from './ibank';
-import ironHandler from './iron';
+import gpHandler from './gp';
 import npmHandler from './npm';
-import nusHandler from './nus';
+import pfHandler from './pf';
 import rdHandler from './rd';
 import twHandler from './tw';
 
@@ -27,10 +26,9 @@ neh.addHandler('dict', dictHandler);
 neh.addHandler('docs', docsHandler);
 neh.addHandler('gh', ghHandler);
 neh.addHandler('gl', glHandler);
-neh.addHandler('ibank', ibankHandler);
-neh.addHandler('iron', ironHandler);
+neh.addHandler('gp', gpHandler);
 neh.addHandler('npm', npmHandler);
-neh.addHandler('nus', nusHandler);
+neh.addHandler('pf', pfHandler);
 neh.addHandler('rd', rdHandler);
 neh.addHandler('tw', twHandler);
 
@@ -143,11 +141,6 @@ neh.addHandler(
 );
 
 neh.addHandler(
-  'rtm',
-  new RedirectHandler('navigates to Remember the Milk', 'https://www.rememberthemilk.com'),
-);
-
-neh.addHandler(
   'so',
   new SearchEngineHandler(
     'does a StackOverflow search',
@@ -215,14 +208,6 @@ neh.addHandler(
       'https://www.youtube.com/results',
       'search_query',
     ),
-  ),
-);
-
-neh.addHandler(
-  'yub',
-  new SearchEngineHandler(
-    'run a YubNub command',
-    makeParamBasedSearchEngine('https://yubnub.org', 'https://yubnub.org/parser/parse', 'command'),
   ),
 );
 

--- a/src/handlers/pf/gh.test.ts
+++ b/src/handlers/pf/gh.test.ts
@@ -1,0 +1,91 @@
+import ghHandler from './gh';
+
+describe('pf gh handler (paraform repo)', () => {
+  test('should redirect to repo if no tokens provided', async () => {
+    const response = await ghHandler.handle([]);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toMatchInlineSnapshot(
+      `"https://github.com/paraform-xyz/paraform"`,
+    );
+  });
+
+  test('should redirect to PR if token is a number', async () => {
+    const response = await ghHandler.handle(['10437']);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toMatchInlineSnapshot(
+      `"https://github.com/paraform-xyz/paraform/pull/10437"`,
+    );
+  });
+
+  test('should redirect to PR search if token is not a number', async () => {
+    const response = await ghHandler.handle(['my', 'feature', 'branch']);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toMatchInlineSnapshot(
+      `"https://github.com/paraform-xyz/paraform/pulls?q=is%3Apr+sort%3Aupdated-desc+my%20feature%20branch"`,
+    );
+  });
+
+  describe('pr subcommand', () => {
+    test('should redirect to open PRs if no tokens provided', async () => {
+      const response = await ghHandler.handle(['pr']);
+      expect(response.status).toBe(302);
+      expect(response.headers.get('location')).toMatchInlineSnapshot(
+        `"https://github.com/paraform-xyz/paraform/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc"`,
+      );
+    });
+
+    test('should redirect to specific PR if token is a number', async () => {
+      const response = await ghHandler.handle(['pr', '10437']);
+      expect(response.status).toBe(302);
+      expect(response.headers.get('location')).toMatchInlineSnapshot(
+        `"https://github.com/paraform-xyz/paraform/pull/10437"`,
+      );
+    });
+  });
+
+  describe('f subcommand', () => {
+    test('should do a filename search', async () => {
+      const response = await ghHandler.handle(['f', 'index.ts']);
+      expect(response.status).toBe(302);
+      expect(response.headers.get('location')).toMatchInlineSnapshot(
+        `"https://github.com/search?type=code&q=repo%3aparaform-xyz/paraform%20filename%3aindex.ts"`,
+      );
+    });
+  });
+
+  describe('s subcommand', () => {
+    test('should do a string search', async () => {
+      const response = await ghHandler.handle(['s', 'some query']);
+      expect(response.status).toBe(302);
+      expect(response.headers.get('location')).toMatchInlineSnapshot(
+        `"https://github.com/paraform-xyz/paraform/search?q=some+query"`,
+      );
+    });
+  });
+});
+
+describe('pf gh infra handler (paraform-infra repo)', () => {
+  test('should redirect to infra repo if no tokens provided', async () => {
+    const response = await ghHandler.handle(['infra']);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toMatchInlineSnapshot(
+      `"https://github.com/paraform-xyz/paraform-infra"`,
+    );
+  });
+
+  test('should redirect to infra PR if token is a number', async () => {
+    const response = await ghHandler.handle(['infra', '42']);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toMatchInlineSnapshot(
+      `"https://github.com/paraform-xyz/paraform-infra/pull/42"`,
+    );
+  });
+
+  test('should redirect to infra PR search if token is not a number', async () => {
+    const response = await ghHandler.handle(['infra', 'network']);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toMatchInlineSnapshot(
+      `"https://github.com/paraform-xyz/paraform-infra/pulls?q=is%3Apr+sort%3Aupdated-desc+network"`,
+    );
+  });
+});

--- a/src/handlers/pf/gh.ts
+++ b/src/handlers/pf/gh.ts
@@ -1,0 +1,60 @@
+import { CommandHandler, RedirectHandler } from '../../Handler';
+import {
+  SearchEngineHandler,
+  makeParamBasedSearchEngine,
+  makeAppendBasedSearchEngine,
+} from '../../SearchEngineHandler';
+
+function makeRepoHandler(repoUrl: string): CommandHandler {
+  const repoPath = repoUrl.replace('https://github.com/', '');
+  const gh = new CommandHandler();
+
+  gh.setNothingHandler(new RedirectHandler('navigates to the GitHub repo', repoUrl));
+
+  gh.addHandler(
+    'f',
+    new SearchEngineHandler(
+      'does a filename search of the GitHub repo',
+      makeAppendBasedSearchEngine(
+        repoUrl,
+        `https://github.com/search?type=code&q=repo%3a${repoPath}%20filename%3a`,
+      ),
+    ),
+  );
+
+  const baseSearchEngine = makeAppendBasedSearchEngine(
+    `${repoUrl}/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc`,
+    `${repoUrl}/pulls?q=is%3Apr+sort%3Aupdated-desc+`,
+  );
+  const prHandler = new SearchEngineHandler('navigates to a specific PR or does a PR search', {
+    ...baseSearchEngine,
+    generateSearchUrl(tokens): string {
+      const prNumberString = tokens[0];
+      const prNumber = parseInt(prNumberString, 10);
+      if (!isNaN(prNumber)) {
+        return `${repoUrl}/pull/${prNumber}`;
+      }
+      return baseSearchEngine.generateSearchUrl(tokens);
+    },
+  });
+  gh.setDefaultHandler(prHandler);
+  gh.addHandler('pr', prHandler);
+
+  gh.addHandler(
+    's',
+    new SearchEngineHandler(
+      'does a string search of the GitHub repo',
+      makeParamBasedSearchEngine(repoUrl, `${repoUrl}/search`, 'q'),
+    ),
+  );
+
+  return gh;
+}
+
+const mainRepoUrl = 'https://github.com/paraform-xyz/paraform';
+const infraRepoUrl = 'https://github.com/paraform-xyz/paraform-infra';
+
+const gh = makeRepoHandler(mainRepoUrl);
+gh.addHandler('infra', makeRepoHandler(infraRepoUrl));
+
+export default gh;

--- a/src/handlers/pf/index.ts
+++ b/src/handlers/pf/index.ts
@@ -1,0 +1,14 @@
+import { CommandHandler, RedirectHandler } from '../../Handler';
+
+import ghHandler from './gh';
+import linearHandler, { linearIssueHandler } from './linear';
+
+const pf = new CommandHandler();
+
+pf.addHandler('gh', ghHandler);
+pf.addHandler('linear', linearHandler);
+
+pf.setNothingHandler(new RedirectHandler('navigates to Paraform', 'https://app.paraform.com'));
+pf.setDefaultHandler(linearIssueHandler);
+
+export default pf;

--- a/src/handlers/pf/linear.test.ts
+++ b/src/handlers/pf/linear.test.ts
@@ -1,0 +1,46 @@
+import { linearIssueHandler } from './linear';
+import linearHandler from './linear';
+
+describe('linearIssueHandler', () => {
+  test('should redirect to issue if provided token is a bare number', async () => {
+    const response = await linearIssueHandler.handle(['1234']);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toMatchInlineSnapshot(
+      `"https://linear.app/paraform/issue/ENG-1234"`,
+    );
+  });
+
+  test('should redirect to issue if provided token is a full ENG- identifier', async () => {
+    const response = await linearIssueHandler.handle(['ENG-5678']);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toMatchInlineSnapshot(
+      `"https://linear.app/paraform/issue/ENG-5678"`,
+    );
+  });
+
+  test('should uppercase ENG- identifiers', async () => {
+    const response = await linearIssueHandler.handle(['eng-42']);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toMatchInlineSnapshot(
+      `"https://linear.app/paraform/issue/ENG-42"`,
+    );
+  });
+
+  test('should redirect to Linear home if token is not a number or ENG- identifier', async () => {
+    const response = await linearIssueHandler.handle(['somequery']);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toMatchInlineSnapshot(
+      `"https://linear.app/paraform"`,
+    );
+  });
+});
+
+describe('linear handler (nothing handler)', () => {
+  test('should redirect to Linear home if no tokens provided', async () => {
+    const response = await linearHandler.handle([]);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toMatchInlineSnapshot(
+      `"https://linear.app/paraform"`,
+    );
+  });
+});

--- a/src/handlers/pf/linear.test.ts
+++ b/src/handlers/pf/linear.test.ts
@@ -29,9 +29,7 @@ describe('linearIssueHandler', () => {
   test('should redirect to Linear home if token is not a number or ENG- identifier', async () => {
     const response = await linearIssueHandler.handle(['somequery']);
     expect(response.status).toBe(302);
-    expect(response.headers.get('location')).toMatchInlineSnapshot(
-      `"https://linear.app/paraform"`,
-    );
+    expect(response.headers.get('location')).toMatchInlineSnapshot(`"https://linear.app/paraform"`);
   });
 });
 
@@ -39,8 +37,6 @@ describe('linear handler (nothing handler)', () => {
   test('should redirect to Linear home if no tokens provided', async () => {
     const response = await linearHandler.handle([]);
     expect(response.status).toBe(302);
-    expect(response.headers.get('location')).toMatchInlineSnapshot(
-      `"https://linear.app/paraform"`,
-    );
+    expect(response.headers.get('location')).toMatchInlineSnapshot(`"https://linear.app/paraform"`);
   });
 });

--- a/src/handlers/pf/linear.ts
+++ b/src/handlers/pf/linear.ts
@@ -1,0 +1,27 @@
+import { CommandHandler, FunctionHandler, RedirectHandler } from '../../Handler';
+import { redirect } from '../../util';
+
+const linear = new CommandHandler();
+
+const linearHomeUrl = 'https://linear.app/paraform';
+
+linear.setNothingHandler(new RedirectHandler('navigates to Paraform Linear', linearHomeUrl));
+
+export const linearIssueHandler = new FunctionHandler(
+  'navigates to a Linear issue',
+  (tokens) => {
+    const ticket = tokens[0];
+    const ticketNumber = parseInt(ticket, 10);
+    if (!isNaN(ticketNumber)) {
+      return redirect(`${linearHomeUrl}/issue/ENG-${ticketNumber}`);
+    }
+    if (ticket.toUpperCase().startsWith('ENG-')) {
+      return redirect(`${linearHomeUrl}/issue/${ticket.toUpperCase()}`);
+    }
+    return redirect(linearHomeUrl);
+  },
+);
+
+linear.setDefaultHandler(linearIssueHandler);
+
+export default linear;

--- a/src/handlers/pf/linear.ts
+++ b/src/handlers/pf/linear.ts
@@ -7,20 +7,17 @@ const linearHomeUrl = 'https://linear.app/paraform';
 
 linear.setNothingHandler(new RedirectHandler('navigates to Paraform Linear', linearHomeUrl));
 
-export const linearIssueHandler = new FunctionHandler(
-  'navigates to a Linear issue',
-  (tokens) => {
-    const ticket = tokens[0];
-    const ticketNumber = parseInt(ticket, 10);
-    if (!isNaN(ticketNumber)) {
-      return redirect(`${linearHomeUrl}/issue/ENG-${ticketNumber}`);
-    }
-    if (ticket.toUpperCase().startsWith('ENG-')) {
-      return redirect(`${linearHomeUrl}/issue/${ticket.toUpperCase()}`);
-    }
-    return redirect(linearHomeUrl);
-  },
-);
+export const linearIssueHandler = new FunctionHandler('navigates to a Linear issue', (tokens) => {
+  const ticket = tokens[0];
+  const ticketNumber = parseInt(ticket, 10);
+  if (!isNaN(ticketNumber)) {
+    return redirect(`${linearHomeUrl}/issue/ENG-${ticketNumber}`);
+  }
+  if (ticket.toUpperCase().startsWith('ENG-')) {
+    return redirect(`${linearHomeUrl}/issue/${ticket.toUpperCase()}`);
+  }
+  return redirect(linearHomeUrl);
+});
 
 linear.setDefaultHandler(linearIssueHandler);
 


### PR DESCRIPTION
## Summary

**New commands:**
- **`pf`** — Paraform hub command
  - `pf ENG-234` / `pf linear ENG-234` → Linear issue (also accepts bare numbers: `pf 234`)
  - `pf gh [PR# | search]` → paraform-xyz/paraform (with `pr`, `f`, `s` subcommands)
  - `pf gh infra [PR# | search]` → paraform-xyz/paraform-infra (same subcommands)
- **`gp`** — Graphite navigation
  - `gp` → https://app.graphite.com/
  - `gp https://github.com/paraform-xyz/paraform/pull/10437` → https://app.graphite.com/github/pr/paraform-xyz/paraform/10437

**Updated commands:**
- **`gh`** — now converts Graphite PR URLs to GitHub: `gh https://app.graphite.com/github/pr/paraform-xyz/paraform/10437` → https://github.com/paraform-xyz/paraform/pull/10437

**Removed commands:** `nus`, `iron`, `ibank`, `rtm`, `yub`

## Pre-Landing Review

No issues found. Pure URL redirect handlers — no SQL, no LLM, no trust boundary concerns. Patterns are structurally identical to the existing `iron/gh` and `iron/jira` handlers.

## Test Coverage

102/102 tests pass. New handlers follow the same patterns as `iron/gh.ts` (5 tests) and `iron/jira.ts` (4 tests), which cover the identical redirect logic.

## Test plan
- [x] All Vitest tests pass (102/102)
- [x] TypeScript typechecks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)