### PR TITLE
feat: support optional JINA_API_KEY to avoid anonymous 429s

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,3 +1,5 @@
 # Copy to .dev.vars and fill in for `wrangler dev` to load these as runtime bindings.
-# For production deploys, set secrets via: wrangler secret put OPENROUTER_API_KEY
+# For production deploys, set secrets via: wrangler secret put <NAME>
 OPENROUTER_API_KEY=
+# Optional. Without it, r.jina.ai is anonymous-rate-limited (sum / tldr will 429 often).
+JINA_API_KEY=

--- a/src/jina.test.ts
+++ b/src/jina.test.ts
@@ -1,0 +1,54 @@
+import fetchMock from 'jest-fetch-mock';
+import { JinaError, fetchAsMarkdown } from './jina';
+
+type GlobalWithKey = { JINA_API_KEY?: string };
+
+function setJinaKey(value: string | undefined): void {
+  (globalThis as unknown as GlobalWithKey).JINA_API_KEY = value;
+}
+
+describe('fetchAsMarkdown', () => {
+  beforeEach(() => {
+    fetchMock.enableMocks();
+    fetchMock.resetMocks();
+    setJinaKey(undefined);
+  });
+
+  afterEach(() => {
+    fetchMock.disableMocks();
+    setJinaKey(undefined);
+  });
+
+  test('sends no Authorization header when JINA_API_KEY is not set', async () => {
+    fetchMock.mockOnce(async () => '# article');
+    await fetchAsMarkdown('https://example.com/post');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://r.jina.ai/https://example.com/post',
+      expect.objectContaining({
+        headers: expect.not.objectContaining({ Authorization: expect.anything() }),
+      }),
+    );
+  });
+
+  test('sends Bearer token when JINA_API_KEY is set', async () => {
+    setJinaKey('jina-secret');
+    fetchMock.mockOnce(async () => '# article');
+    await fetchAsMarkdown('https://example.com/post');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://r.jina.ai/https://example.com/post',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Accept: 'text/plain',
+          Authorization: 'Bearer jina-secret',
+        }),
+      }),
+    );
+  });
+
+  test('throws JinaError on non-ok response', async () => {
+    fetchMock.mockOnce(async () => ({ init: { status: 429 }, body: 'rate limited' }));
+    await expect(fetchAsMarkdown('https://example.com/post')).rejects.toBeInstanceOf(JinaError);
+  });
+});

--- a/src/jina.ts
+++ b/src/jina.ts
@@ -3,9 +3,13 @@ const JINA_BASE = 'https://r.jina.ai/';
 export class JinaError extends Error {}
 
 export async function fetchAsMarkdown(targetUrl: string): Promise<string> {
-  const response = await fetch(`${JINA_BASE}${targetUrl}`, {
-    headers: { Accept: 'text/plain' },
-  });
+  const apiKey = (globalThis as unknown as { JINA_API_KEY?: string }).JINA_API_KEY;
+  const headers: Record<string, string> = { Accept: 'text/plain' };
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+
+  const response = await fetch(`${JINA_BASE}${targetUrl}`, { headers });
   if (!response.ok) {
     throw new JinaError(`Jina Reader returned ${response.status} for ${targetUrl}`);
   }


### PR DESCRIPTION
## Summary

- Anonymous access to `r.jina.ai` was rate-limiting `sum` / `tldr` in real use (429s).
- `src/jina.ts` now reads `JINA_API_KEY` from the Workers environment. If set, it sends `Authorization: Bearer <key>`. If unset, requests stay anonymous and continue to work — just at the anonymous rate limit.
- Key remains optional: nothing breaks for contributors or deploys that don't set it.

## Setup

- Local: add `JINA_API_KEY=` to `.dev.vars`.
- Production: `wrangler secret put JINA_API_KEY`.

## Test plan

- [x] New `src/jina.test.ts` covers: no Authorization header when unset, Bearer header when set, JinaError on non-ok response.
- [x] Coverage remains 100% statements / 100% branches / 100% functions / 100% lines (127 tests, up from 124).
- [x] Smoke on preview: `sum https://paulgraham.com/schlep.html` no longer 429s with the key in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)