### PR TITLE
fix: update paraform URL to www.paraform.com

### DIFF
--- a/src/handlers/pf/index.ts
+++ b/src/handlers/pf/index.ts
@@ -8,7 +8,7 @@ const pf = new CommandHandler();
 pf.addHandler('gh', ghHandler);
 pf.addHandler('linear', linearHandler);
 
-pf.setNothingHandler(new RedirectHandler('navigates to Paraform', 'https://app.paraform.com'));
+pf.setNothingHandler(new RedirectHandler('navigates to Paraform', 'https://www.paraform.com'));
 pf.setDefaultHandler(linearIssueHandler);
 
 export default pf;


### PR DESCRIPTION
Update the paraform redirect URL from app.paraform.com to www.paraform.com

- Tests pass locally