### PR TITLE
Ground AI search in real Brave Search results to eliminate hallucinated URLs

### DIFF
--- a/src/brave.ts
+++ b/src/brave.ts
@@ -1,0 +1,42 @@
+const BRAVE_SEARCH_URL = 'https://api.search.brave.com/res/v1/web/search';
+
+export interface BraveResult {
+  url: string;
+  title: string;
+  description: string;
+}
+
+export class BraveSearchError extends Error {}
+
+export async function searchBrave(query: string, count = 5): Promise<BraveResult[]> {
+  const apiKey = (globalThis as unknown as { BRAVE_SEARCH_API_KEY?: string }).BRAVE_SEARCH_API_KEY;
+  if (!apiKey) {
+    throw new BraveSearchError('BRAVE_SEARCH_API_KEY is not configured');
+  }
+
+  const url = new URL(BRAVE_SEARCH_URL);
+  url.searchParams.set('q', query);
+  url.searchParams.set('count', String(count));
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Accept: 'application/json',
+      'Accept-Encoding': 'gzip',
+      'X-Subscription-Token': apiKey,
+    },
+  });
+
+  if (!response.ok) {
+    throw new BraveSearchError(`Brave Search returned ${response.status}`);
+  }
+
+  const data = (await response.json()) as {
+    web?: { results?: { url: string; title: string; description?: string }[] };
+  };
+
+  return (data.web?.results ?? []).map((r) => ({
+    url: r.url,
+    title: r.title,
+    description: r.description ?? '',
+  }));
+}

--- a/src/handlers/ai.test.ts
+++ b/src/handlers/ai.test.ts
@@ -1,14 +1,26 @@
 import fetchMock from 'jest-fetch-mock';
 import aiHandler from './ai';
 
-type GlobalWithKey = { OPENROUTER_API_KEY?: string };
+type GlobalWithKeys = { OPENROUTER_API_KEY?: string; BRAVE_SEARCH_API_KEY?: string };
 
 function setApiKey(value: string | undefined): void {
-  (globalThis as unknown as GlobalWithKey).OPENROUTER_API_KEY = value;
+  (globalThis as unknown as GlobalWithKeys).OPENROUTER_API_KEY = value;
+}
+
+function setBraveKey(value: string | undefined): void {
+  (globalThis as unknown as GlobalWithKeys).BRAVE_SEARCH_API_KEY = value;
 }
 
 function mockOpenRouterReply(content: string): void {
   fetchMock.mockOnce(async () => JSON.stringify({ choices: [{ message: { content } }] }));
+}
+
+function mockBraveReply(results: { url: string; title: string; description?: string }[]): void {
+  fetchMock.mockOnce(async () => JSON.stringify({ web: { results } }));
+}
+
+function mockBraveError(status: number): void {
+  fetchMock.mockOnce(async () => ({ init: { status }, body: 'error' }));
 }
 
 describe('ai handler', () => {
@@ -16,11 +28,13 @@ describe('ai handler', () => {
     fetchMock.enableMocks();
     fetchMock.resetMocks();
     setApiKey('test-key');
+    setBraveKey(undefined);
   });
 
   afterEach(() => {
     fetchMock.disableMocks();
     setApiKey(undefined);
+    setBraveKey(undefined);
   });
 
   test('redirects to DuckDuckGo home when no tokens given', async () => {
@@ -29,7 +43,9 @@ describe('ai handler', () => {
     expect(response.headers.get('location')).toBe('https://duckduckgo.com');
   });
 
-  test('redirects to the URL the LLM returns', async () => {
+  // --- Brave key absent: falls through to LLM-only (original behavior) ---
+
+  test('redirects to the URL the LLM returns when Brave key is absent', async () => {
     mockOpenRouterReply('https://react.dev/reference/react/useEffect');
 
     const response = await aiHandler.handle(['react', 'useEffect', 'docs']);
@@ -75,5 +91,54 @@ describe('ai handler', () => {
     const response = await aiHandler.handle(['no', 'key']);
     expect(response.status).toBe(302);
     expect(response.headers.get('location')).toBe('https://duckduckgo.com/?q=no%20key');
+  });
+
+  // --- Brave key present: search-then-select path ---
+
+  test('selects from Brave results when Brave key is set', async () => {
+    setBraveKey('brave-key');
+    mockBraveReply([
+      {
+        url: 'https://react.dev/reference/react/useEffect',
+        title: 'useEffect – React',
+        description: 'React hook docs',
+      },
+      { url: 'https://example.com/other', title: 'Other', description: 'Something else' },
+    ]);
+    mockOpenRouterReply('https://react.dev/reference/react/useEffect');
+
+    const response = await aiHandler.handle(['react', 'useEffect', 'docs']);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('https://react.dev/reference/react/useEffect');
+  });
+
+  test('falls back to LLM-only when Brave returns no results', async () => {
+    setBraveKey('brave-key');
+    mockBraveReply([]);
+    mockOpenRouterReply('https://react.dev/reference/react/useEffect');
+
+    const response = await aiHandler.handle(['react', 'useEffect', 'docs']);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('https://react.dev/reference/react/useEffect');
+  });
+
+  test('falls back to LLM-only when Brave returns an HTTP error', async () => {
+    setBraveKey('brave-key');
+    mockBraveError(500);
+    mockOpenRouterReply('https://react.dev/reference/react/useEffect');
+
+    const response = await aiHandler.handle(['react', 'useEffect', 'docs']);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('https://react.dev/reference/react/useEffect');
+  });
+
+  test('falls back to DuckDuckGo when both Brave and LLM fail', async () => {
+    setBraveKey('brave-key');
+    mockBraveError(503);
+    fetchMock.mockRejectOnce(new Error('LLM down'));
+
+    const response = await aiHandler.handle(['some', 'query']);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('https://duckduckgo.com/?q=some%20query');
   });
 });

--- a/src/handlers/ai.ts
+++ b/src/handlers/ai.ts
@@ -1,7 +1,8 @@
 import { FunctionHandler } from '../Handler';
 import { callModel } from '../llm';
-import { AI_SYSTEM } from '../prompts';
+import { AI_SEARCH_SYSTEM, AI_SYSTEM } from '../prompts';
 import { redirect } from '../util';
+import { BraveSearchError, searchBrave } from '../brave';
 
 function ddgFor(query: string): string {
   return `https://duckduckgo.com/?q=${encodeURIComponent(query)}`;
@@ -18,6 +19,21 @@ function extractUrl(raw: string): string | null {
   }
 }
 
+async function selectFromSearch(query: string): Promise<string | null> {
+  const results = await searchBrave(query, 5);
+  if (results.length === 0) return null;
+
+  const list = results
+    .map((r, i) => `${i + 1}. [${r.title}](${r.url})\n   ${r.description}`)
+    .join('\n');
+
+  const response = await callModel([
+    { role: 'system', content: AI_SEARCH_SYSTEM },
+    { role: 'user', content: `Query: ${query}\n\nSearch results:\n${list}` },
+  ]);
+  return extractUrl(response);
+}
+
 const aiHandler = new FunctionHandler(
   'asks an LLM for the best destination URL for your query',
   async (tokens) => {
@@ -25,6 +41,17 @@ const aiHandler = new FunctionHandler(
       return redirect('https://duckduckgo.com');
     }
     const query = tokens.join(' ');
+
+    // Grounded path: real URLs from Brave → LLM selects best
+    try {
+      const url = await selectFromSearch(query);
+      if (url) return redirect(url);
+    } catch (e) {
+      if (!(e instanceof BraveSearchError)) throw e;
+      // Brave unavailable → fall through to LLM-only
+    }
+
+    // Fallback: LLM generates URL from memory (original behavior)
     try {
       const response = await callModel([
         { role: 'system', content: AI_SYSTEM },

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -11,3 +11,5 @@ Examples:
 - "hacker news" -> https://news.ycombinator.com
 
 If nothing obvious fits, respond with a DuckDuckGo search URL of the form https://duckduckgo.com/?q=<url-encoded-query>.`;
+
+export const AI_SEARCH_SYSTEM = `You are a URL selector. Given a user query and a list of real search results, pick the single best URL from those results. Respond with only the URL, no prose, no markdown, no quotes.`;


### PR DESCRIPTION
## Summary
- Adds Brave Search API integration to ground AI URL selection in real results
- AI handler now queries Brave first and uses LLM to select the best result
- Gracefully falls back to LLM-only if Brave is unavailable
- New `AI_SEARCH_SYSTEM` prompt for intelligent result selection
- Comprehensive test coverage for all paths (Brave present/absent, errors, fallbacks)

## Test plan
- [x] All existing AI handler tests pass
- [x] New Brave Search integration tests cover happy path
- [x] Tests verify fallback behavior when Brave unavailable
- [x] Tests verify both Brave and LLM failures fall back to DuckDuckGo

🤖 Generated with [Claude Code](https://claude.com/claude-code)