### PR TITLE
Add custom prompt handler for applying ad-hoc instructions to URLs

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -6,7 +6,7 @@ Response {
   "bodyUsed": false,
   "headers": Headers {
     "_map": Map {
-      "location" => "https://duckduckgo.com/?q=1+%2B+1",
+      "location" => "https://duckduckgo.com/?q=1%20%2B%201",
     },
   },
   "method": "GET",
@@ -25,7 +25,7 @@ Response {
   "bodyUsed": false,
   "headers": Headers {
     "_map": Map {
-      "location" => "https://duckduckgo.com/?q=1+%2B+1",
+      "location" => "https://duckduckgo.com/?q=1%20%2B%201",
     },
   },
   "method": "GET",
@@ -234,7 +234,7 @@ Response {
   "bodyUsed": false,
   "headers": Headers {
     "_map": Map {
-      "location" => "https://duckduckgo.com/?q=search+query",
+      "location" => "https://duckduckgo.com/?q=search%20query",
     },
   },
   "method": "GET",
@@ -253,7 +253,7 @@ Response {
   "bodyUsed": false,
   "headers": Headers {
     "_map": Map {
-      "location" => "https://duckduckgo.com/?q=search+query",
+      "location" => "https://duckduckgo.com/?q=search%20query",
     },
   },
   "method": "GET",

--- a/src/handlers/custom.test.ts
+++ b/src/handlers/custom.test.ts
@@ -116,4 +116,10 @@ describe('custom prompt handler', () => {
     expect(response.status).toBe(500);
     expect(await response.text()).toContain('OpenRouter returned 500');
   });
+
+  test('renders an error page for invalid URLs', async () => {
+    const response = await customPromptHandler.handle(['summarize', 'https://example.com:invalid']);
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain('Not a valid URL');
+  });
 });

--- a/src/handlers/custom.test.ts
+++ b/src/handlers/custom.test.ts
@@ -65,11 +65,7 @@ describe('custom prompt handler', () => {
       [JSON.stringify({ choices: [{ message: { content: 'result' } }] }), { status: 200 }],
     );
 
-    const response = await customPromptHandler.handle([
-      'extract',
-      'URLs',
-      'https://example.com',
-    ]);
+    const response = await customPromptHandler.handle(['extract', 'URLs', 'https://example.com']);
     const body = await response.text();
     expect(body).toContain('extract URLs');
   });
@@ -105,10 +101,7 @@ describe('custom prompt handler', () => {
   test('renders an error page when Jina Reader fails', async () => {
     fetchMock.mockResponseOnce('not found', { status: 404 });
 
-    const response = await customPromptHandler.handle([
-      'summarize',
-      'https://example.com/missing',
-    ]);
+    const response = await customPromptHandler.handle(['summarize', 'https://example.com/missing']);
     expect(response.status).toBe(500);
     expect(await response.text()).toContain('Jina Reader returned 404');
   });
@@ -119,10 +112,7 @@ describe('custom prompt handler', () => {
       ['server exploded', { status: 500 }],
     );
 
-    const response = await customPromptHandler.handle([
-      'summarize',
-      'https://example.com/article',
-    ]);
+    const response = await customPromptHandler.handle(['summarize', 'https://example.com/article']);
     expect(response.status).toBe(500);
     expect(await response.text()).toContain('OpenRouter returned 500');
   });

--- a/src/handlers/custom.test.ts
+++ b/src/handlers/custom.test.ts
@@ -1,0 +1,129 @@
+import fetchMock from 'jest-fetch-mock';
+import customPromptHandler from './custom';
+
+type GlobalWithKey = { OPENROUTER_API_KEY?: string };
+
+function setApiKey(value: string | undefined): void {
+  (globalThis as unknown as GlobalWithKey).OPENROUTER_API_KEY = value;
+}
+
+describe('custom prompt handler', () => {
+  beforeEach(() => {
+    fetchMock.enableMocks();
+    fetchMock.resetMocks();
+    setApiKey('test-key');
+  });
+
+  afterEach(() => {
+    fetchMock.disableMocks();
+    setApiKey(undefined);
+  });
+
+  test('redirects to DuckDuckGo when no URL is present', async () => {
+    const response = await customPromptHandler.handle(['just', 'a', 'search']);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toContain('duckduckgo.com');
+    expect(response.headers.get('location')).toContain('just%20a%20search');
+  });
+
+  test('redirects to DuckDuckGo when URL is present but no prompt', async () => {
+    const response = await customPromptHandler.handle(['https://example.com']);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toContain('duckduckgo.com');
+  });
+
+  test('applies prompt as system message and page content as user message', async () => {
+    fetchMock.mockResponses(
+      ['# Pricing\n\n| Plan | Price |\n| --- | --- |\n| Free | $0 |', { status: 200 }],
+      [
+        JSON.stringify({ choices: [{ message: { content: '| Plan | Price |\n| --- | --- |' } }] }),
+        { status: 200 },
+      ],
+    );
+
+    const response = await customPromptHandler.handle([
+      'the',
+      'table',
+      'in',
+      'markdown',
+      'https://example.com/pricing',
+    ]);
+    expect(response.status).toBe(200);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://openrouter.ai/api/v1/chat/completions',
+      expect.objectContaining({
+        body: expect.stringContaining('"role":"system","content":"the table in markdown"'),
+      }),
+    );
+  });
+
+  test('uses the prompt as the result page label', async () => {
+    fetchMock.mockResponses(
+      ['content', { status: 200 }],
+      [JSON.stringify({ choices: [{ message: { content: 'result' } }] }), { status: 200 }],
+    );
+
+    const response = await customPromptHandler.handle([
+      'extract',
+      'URLs',
+      'https://example.com',
+    ]);
+    const body = await response.text();
+    expect(body).toContain('extract URLs');
+  });
+
+  test('works with no space between prompt and URL', async () => {
+    fetchMock.mockResponses(
+      ['content', { status: 200 }],
+      [JSON.stringify({ choices: [{ message: { content: 'result' } }] }), { status: 200 }],
+    );
+
+    const response = await customPromptHandler.handle([
+      'the',
+      'table',
+      'in',
+      'markdownhttps://example.com/pricing',
+    ]);
+    expect(response.status).toBe(200);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://r.jina.ai/https://example.com/pricing',
+      expect.anything(),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://openrouter.ai/api/v1/chat/completions',
+      expect.objectContaining({
+        body: expect.stringContaining('"role":"system","content":"the table in markdown"'),
+      }),
+    );
+  });
+
+  test('renders an error page when Jina Reader fails', async () => {
+    fetchMock.mockResponseOnce('not found', { status: 404 });
+
+    const response = await customPromptHandler.handle([
+      'summarize',
+      'https://example.com/missing',
+    ]);
+    expect(response.status).toBe(500);
+    expect(await response.text()).toContain('Jina Reader returned 404');
+  });
+
+  test('renders an error page when the this exact phrase, but honest call fails', async () => {
+    fetchMock.mockResponses(
+      ['some content', { status: 200 }],
+      ['server exploded', { status: 500 }],
+    );
+
+    const response = await customPromptHandler.handle([
+      'summarize',
+      'https://example.com/article',
+    ]);
+    expect(response.status).toBe(500);
+    expect(await response.text()).toContain('OpenRouter returned 500');
+  });
+});

--- a/src/handlers/custom.ts
+++ b/src/handlers/custom.ts
@@ -1,6 +1,6 @@
 import { FunctionHandler, Token } from '../Handler';
 import { fetchAsMarkdown } from '../jina';
-import { callModel } from '../this exact phrase, but honest';
+import { callModel } from '../llm';
 import { renderErrorPage, renderResultPage } from '../resultPage';
 import { redirect } from '../util';
 
@@ -12,7 +12,7 @@ function splitAtUrl(query: string): { prompt: string; url: string } | null {
 }
 
 const customPromptHandler = new FunctionHandler(
-  'applies a custom this exact phrase, but honest prompt to a URL, e.g. "the table in markdown https://example.com"',
+  'applies a custom prompt to a URL, e.g. "the table in markdown https://example.com"',
   async (tokens: Token[]) => {
     const query = tokens.join(' ');
     const parts = splitAtUrl(query);

--- a/src/handlers/custom.ts
+++ b/src/handlers/custom.ts
@@ -1,0 +1,45 @@
+import { FunctionHandler, Token } from '../Handler';
+import { fetchAsMarkdown } from '../jina';
+import { callModel } from '../this exact phrase, but honest';
+import { renderErrorPage, renderResultPage } from '../resultPage';
+import { redirect } from '../util';
+
+function splitAtUrl(query: string): { prompt: string; url: string } | null {
+  const match = query.match(/(https?:\/\/\S+)/);
+  if (!match) return null;
+  const urlStart = query.indexOf(match[1]);
+  return { prompt: query.slice(0, urlStart).trim(), url: match[1] };
+}
+
+const customPromptHandler = new FunctionHandler(
+  'applies a custom this exact phrase, but honest prompt to a URL, e.g. "the table in markdown https://example.com"',
+  async (tokens: Token[]) => {
+    const query = tokens.join(' ');
+    const parts = splitAtUrl(query);
+
+    if (!parts || !parts.prompt) {
+      return redirect(`https://duckduckgo.com/?q=${encodeURIComponent(query)}`);
+    }
+
+    const { prompt, url } = parts;
+
+    try {
+      new URL(url);
+    } catch {
+      return renderErrorPage('custom', `Not a valid URL: ${url}`, 400);
+    }
+
+    try {
+      const markdown = await fetchAsMarkdown(url);
+      const result = await callModel([
+        { role: 'system', content: prompt },
+        { role: 'user', content: markdown },
+      ]);
+      return renderResultPage(prompt, result, url);
+    } catch (err) {
+      return renderErrorPage('custom', (err as Error).message);
+    }
+  },
+);
+
+export default customPromptHandler;

--- a/src/handlers/index.test.ts
+++ b/src/handlers/index.test.ts
@@ -7,10 +7,10 @@ describe('neh global handler', () => {
     expect(homeResponse).toEqual(listResponse);
   });
 
-  test('should default to DuckDuckGo', async () => {
-    const tokens = ['search', 'query'];
-    const homeResponse = await handler.handle(tokens);
-    const dResponse = await handler.handle(['d', ...tokens]);
-    expect(homeResponse).toEqual(dResponse);
+  test('should default to DuckDuckGo for queries without a URL', async () => {
+    const response = await handler.handle(['search', 'query']);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toContain('duckduckgo.com');
+    expect(response.headers.get('location')).toContain('search');
   });
 });

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -8,6 +8,7 @@ import {
 import { redirect } from '../util';
 
 import aiHandler from './ai';
+import customPromptHandler from './custom';
 import dictHandler from './dict';
 import docsHandler from './docs';
 import ghHandler from './gh';
@@ -59,7 +60,7 @@ const dHandler = new SearchEngineHandler(
   makeParamBasedSearchEngine('https://duckduckgo.com/', null, 'q'),
 );
 neh.addHandler('d', dHandler);
-neh.setDefaultHandler(dHandler);
+neh.setDefaultHandler(customPromptHandler);
 
 neh.addHandler(
   'do',


### PR DESCRIPTION
## Summary
- New custom prompt handler that lets users apply arbitrary prompts to web page content
- Format: type a prompt followed by a URL (e.g., 'the table in markdown https://example.com')
- Fetches pages via Jina Reader and applies the prompt as a system instruction
- URL start (https://) serves as the natural separator—no command prefix needed
- Falls back to DuckDuckGo for queries without a URL

## Test plan
- [x] Tested with URL-based prompts
- [x] Verified fallback to DuckDuckGo for query-only input

🤖 Generated with [Claude Code](https://claude.com/claude-code)