### PR TITLE
Add redirect handler for Claude Code shortcut

### DIFF
--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -53,6 +53,8 @@ neh.addHandler(
   ),
 );
 
+neh.addHandler('cc', new RedirectHandler('navigates to Claude Code', 'https://claude.ai/code'));
+
 neh.addHandler('cf', new RedirectHandler('navigates to Cloudflare', 'https://dash.cloudflare.com'));
 
 const dHandler = new SearchEngineHandler(


### PR DESCRIPTION
## Summary
Added a new redirect handler for the 'cc' shortcut that navigates to Claude Code.

## Changes
- Added a new `RedirectHandler` for the 'cc' shortcut that directs users to https://claude.ai/code
- The handler is positioned between the existing handlers, maintaining alphabetical ordering by shortcut key

## Implementation Details
The new handler follows the same pattern as existing redirect handlers (e.g., 'cf' for Cloudflare), providing a convenient shortcut for quick navigation to Claude Code.

https://claude.ai/code/session_0143JnaSsmYKFA9KpYmdWZz3