### PR TITLE
Add Datadog handler with logs, APM, DBM, RUM support and URL rewrite

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -38,6 +38,120 @@ Response {
 }
 `;
 
+exports[`neh > should handle "dd" "%20"-spaced query correctly 1`] = `
+Response {
+  "body": null,
+  "bodyUsed": false,
+  "headers": Headers {
+    "_map": Map {
+      "location" => "https://app.datadoghq.com/logs/livetail",
+    },
+  },
+  "method": "GET",
+  "ok": false,
+  "redirected": false,
+  "status": 302,
+  "statusText": "OK",
+  "type": "basic",
+  "url": "http://example.com/asset",
+}
+`;
+
+exports[`neh > should handle "dd" "+"-spaced query correctly 1`] = `
+Response {
+  "body": null,
+  "bodyUsed": false,
+  "headers": Headers {
+    "_map": Map {
+      "location" => "https://app.datadoghq.com/logs/livetail",
+    },
+  },
+  "method": "GET",
+  "ok": false,
+  "redirected": false,
+  "status": 302,
+  "statusText": "OK",
+  "type": "basic",
+  "url": "http://example.com/asset",
+}
+`;
+
+exports[`neh > should handle "dd%20apm%20services" "%20"-spaced query correctly 1`] = `
+Response {
+  "body": null,
+  "bodyUsed": false,
+  "headers": Headers {
+    "_map": Map {
+      "location" => "https://app.datadoghq.com/apm/services",
+    },
+  },
+  "method": "GET",
+  "ok": false,
+  "redirected": false,
+  "status": 302,
+  "statusText": "OK",
+  "type": "basic",
+  "url": "http://example.com/asset",
+}
+`;
+
+exports[`neh > should handle "dd%20status:error%20service:paraform" "%20"-spaced query correctly 1`] = `
+Response {
+  "body": null,
+  "bodyUsed": false,
+  "headers": Headers {
+    "_map": Map {
+      "location" => "https://app.datadoghq.com/logs?query=status%3Aerror%20service%3Aparaform",
+    },
+  },
+  "method": "GET",
+  "ok": false,
+  "redirected": false,
+  "status": 302,
+  "statusText": "OK",
+  "type": "basic",
+  "url": "http://example.com/asset",
+}
+`;
+
+exports[`neh > should handle "dd+apm+services" "+"-spaced query correctly 1`] = `
+Response {
+  "body": null,
+  "bodyUsed": false,
+  "headers": Headers {
+    "_map": Map {
+      "location" => "https://app.datadoghq.com/apm/services",
+    },
+  },
+  "method": "GET",
+  "ok": false,
+  "redirected": false,
+  "status": 302,
+  "statusText": "OK",
+  "type": "basic",
+  "url": "http://example.com/asset",
+}
+`;
+
+exports[`neh > should handle "dd+status:error+service:paraform" "+"-spaced query correctly 1`] = `
+Response {
+  "body": null,
+  "bodyUsed": false,
+  "headers": Headers {
+    "_map": Map {
+      "location" => "https://app.datadoghq.com/logs?query=status%3Aerror%20service%3Aparaform",
+    },
+  },
+  "method": "GET",
+  "ok": false,
+  "redirected": false,
+  "status": 302,
+  "statusText": "OK",
+  "type": "basic",
+  "url": "http://example.com/asset",
+}
+`;
+
 exports[`neh > should handle "drive" "%20"-spaced query correctly 1`] = `
 Response {
   "body": null,

--- a/src/handlers/dd/datadog.test.ts
+++ b/src/handlers/dd/datadog.test.ts
@@ -1,0 +1,33 @@
+import { DD_BASE, makeDatadogQuerySearchEngine } from './datadog';
+
+describe(makeDatadogQuerySearchEngine, () => {
+  const engine = makeDatadogQuerySearchEngine('/logs');
+
+  describe('generateSearchUrl', () => {
+    test('builds a query= URL with %20-encoded spaces', () => {
+      expect(engine.generateSearchUrl(['status:error', 'service:paraform'])).toBe(
+        `${DD_BASE}/logs?query=status%3Aerror%20service%3Aparaform`,
+      );
+    });
+  });
+
+  describe('parseSearchUrl', () => {
+    test('extracts and decodes the query from a Datadog URL', () => {
+      expect(engine.parseSearchUrl?.(`${DD_BASE}/logs?query=status%3Aerror&cols=host`)).toBe(
+        'status:error',
+      );
+    });
+
+    test('returns null for a non-Datadog URL', () => {
+      expect(engine.parseSearchUrl?.('https://example.com/logs?query=foo')).toBeNull();
+    });
+
+    test('returns null when there is no query param', () => {
+      expect(engine.parseSearchUrl?.(`${DD_BASE}/logs?cols=host`)).toBeNull();
+    });
+
+    test('returns null for an empty query param', () => {
+      expect(engine.parseSearchUrl?.(`${DD_BASE}/logs?query=&cols=host`)).toBeNull();
+    });
+  });
+});

--- a/src/handlers/dd/datadog.ts
+++ b/src/handlers/dd/datadog.ts
@@ -1,0 +1,38 @@
+import { SearchEngine } from '../../SearchEngineHandler';
+
+export const DD_BASE = 'https://app.datadoghq.com';
+
+/**
+ * Builds a SearchEngine for a Datadog product whose query is carried in a
+ * `?query=` param (Logs, APM traces, RUM, etc.).
+ *
+ * We can't use makeParamBasedSearchEngine here: it encodes spaces as `+`,
+ * whereas Datadog's query parser expects `%20` (and `%3A`/`%40`/`%2F` for the
+ * facet syntax). So we build the URL ourselves with encodeURIComponent.
+ */
+export function makeDatadogQuerySearchEngine(path: string): SearchEngine {
+  const defaultUrl = `${DD_BASE}${path}`;
+  return {
+    defaultUrl,
+
+    generateSearchUrl(tokens): string {
+      return `${defaultUrl}?query=${encodeURIComponent(tokens.join(' '))}`;
+    },
+
+    parseSearchUrl(url): string | null {
+      // String-based extraction rather than `new URL()`: a Datadog query can
+      // contain a literal `#` (e.g. tag facets like `#api_no_api:`), which the
+      // URL parser would treat as the start of the fragment, truncating the
+      // query.
+      if (!url.startsWith(`${DD_BASE}/`)) {
+        return null;
+      }
+      const match = url.match(/[?&]query=([^&#]*)/);
+      if (!match) {
+        return null;
+      }
+      const query = decodeURIComponent(match[1]);
+      return query.length > 0 ? query : null;
+    },
+  };
+}

--- a/src/handlers/dd/index.test.ts
+++ b/src/handlers/dd/index.test.ts
@@ -1,0 +1,54 @@
+import dd from '.';
+
+async function location(tokens: string[]): Promise<string> {
+  const response = await dd.handle(tokens);
+  expect(response.status).toBe(302);
+  return response.headers.get('location') ?? '';
+}
+
+describe('dd handler', () => {
+  test('bare dd goes to Live Tail', async () => {
+    expect(await location([])).toBe('https://app.datadoghq.com/logs/livetail');
+  });
+
+  test('free text does a logs search', async () => {
+    expect(await location(['status:error', 'service:paraform'])).toBe(
+      'https://app.datadoghq.com/logs?query=status%3Aerror%20service%3Aparaform',
+    );
+  });
+
+  test('dd l searches logs', async () => {
+    expect(await location(['l', 'error'])).toBe('https://app.datadoghq.com/logs?query=error');
+  });
+
+  test('dd lt goes to Live Tail', async () => {
+    expect(await location(['lt'])).toBe('https://app.datadoghq.com/logs/livetail');
+  });
+
+  test('dd apm searches traces', async () => {
+    expect(await location(['apm', 'foo'])).toBe('https://app.datadoghq.com/apm/traces?query=foo');
+  });
+
+  test('dd apm services goes to services', async () => {
+    expect(await location(['apm', 'services'])).toBe('https://app.datadoghq.com/apm/services');
+    expect(await location(['a', 's'])).toBe('https://app.datadoghq.com/apm/services');
+  });
+
+  test('dd dbm goes to Database Monitoring', async () => {
+    expect(await location(['dbm'])).toBe('https://app.datadoghq.com/databases');
+  });
+
+  test('dd dbm q goes to query metrics', async () => {
+    expect(await location(['dbm', 'q'])).toBe('https://app.datadoghq.com/databases/query-metrics');
+  });
+
+  test('dd rum searches the explorer', async () => {
+    expect(await location(['rum', 'bar'])).toBe('https://app.datadoghq.com/rum/explorer?query=bar');
+  });
+
+  test('dd rw with no rewrite lists available rewrites', async () => {
+    const response = await dd.handle(['rw']);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('api');
+  });
+});

--- a/src/handlers/dd/index.ts
+++ b/src/handlers/dd/index.ts
@@ -1,0 +1,65 @@
+import { CommandHandler, RedirectHandler } from '../../Handler';
+import { SearchEngineHandler } from '../../SearchEngineHandler';
+
+import { DD_BASE, makeDatadogQuerySearchEngine } from './datadog';
+import rewriteHandler from './rewrite';
+
+const dd = new CommandHandler();
+
+const liveTailUrl = `${DD_BASE}/logs/livetail`;
+
+// Logs (heaviest use): bare `dd` lands on Live Tail, `dd <query>` searches logs.
+const logsSearchHandler = new SearchEngineHandler(
+  'does a Datadog logs search',
+  makeDatadogQuerySearchEngine('/logs'),
+);
+
+dd.setNothingHandler(new RedirectHandler('navigates to Datadog Live Tail', liveTailUrl));
+dd.setDefaultHandler(logsSearchHandler);
+
+dd.addHandler('logs', logsSearchHandler);
+dd.addHandler('l', logsSearchHandler);
+dd.addHandler('lt', new RedirectHandler('navigates to Datadog Live Tail', liveTailUrl));
+dd.addHandler('livetail', new RedirectHandler('navigates to Datadog Live Tail', liveTailUrl));
+
+// APM
+const apm = new CommandHandler();
+const apmTracesHandler = new SearchEngineHandler(
+  'does a Datadog APM trace search',
+  makeDatadogQuerySearchEngine('/apm/traces'),
+);
+apm.setNothingHandler(apmTracesHandler);
+apm.setDefaultHandler(apmTracesHandler);
+const apmServicesHandler = new RedirectHandler(
+  'navigates to Datadog APM services',
+  `${DD_BASE}/apm/services`,
+);
+apm.addHandler('s', apmServicesHandler);
+apm.addHandler('services', apmServicesHandler);
+dd.addHandler('apm', apm);
+dd.addHandler('a', apm);
+
+// DBM (no simple query= search surface; redirects only)
+const dbm = new CommandHandler();
+dbm.setNothingHandler(
+  new RedirectHandler('navigates to Datadog Database Monitoring', `${DD_BASE}/databases`),
+);
+const dbmQueriesHandler = new RedirectHandler(
+  'navigates to Datadog DBM query metrics',
+  `${DD_BASE}/databases/query-metrics`,
+);
+dbm.addHandler('q', dbmQueriesHandler);
+dbm.addHandler('queries', dbmQueriesHandler);
+dd.addHandler('dbm', dbm);
+
+// RUM
+const rumExplorerHandler = new SearchEngineHandler(
+  'does a Datadog RUM search',
+  makeDatadogQuerySearchEngine('/rum/explorer'),
+);
+dd.addHandler('rum', rumExplorerHandler);
+
+// URL rewrites
+dd.addHandler('rw', rewriteHandler);
+
+export default dd;

--- a/src/handlers/dd/rewrite/api.test.ts
+++ b/src/handlers/dd/rewrite/api.test.ts
@@ -56,4 +56,10 @@ describe('dd rw api handler', () => {
     expect(response.status).toBe(400);
     expect(await response.text()).toContain('expects a full Datadog logs URL');
   });
+
+  test('returns an error for a URL without a query string', async () => {
+    const response = await apiRewriteHandler.handle(['https://app.datadoghq.com/logs']);
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain('expects a full Datadog logs URL');
+  });
 });

--- a/src/handlers/dd/rewrite/api.test.ts
+++ b/src/handlers/dd/rewrite/api.test.ts
@@ -1,0 +1,59 @@
+import apiRewriteHandler from './api';
+
+// neh decodes the incoming query and splits it on spaces before a handler sees
+// it, so a pasted Datadog URL arrives as space-split, fully-decoded tokens.
+function tokensFor(decodedUrl: string): string[] {
+  return decodedUrl.split(' ');
+}
+
+function locationQuery(response: Response): string {
+  const location = response.headers.get('location') ?? '';
+  return new URL(location).searchParams.get('query') ?? '';
+}
+
+describe('dd rw api handler', () => {
+  test('rewrites #api_no_api to @api:/api/ for the documented example', async () => {
+    const url =
+      'https://app.datadoghq.com/logs?query=service:paraform @api:* status:error AND #api_no_api:trpc\\/company.getCompanySlackIds&calculated_fields=&cols=host,service&fromUser=true&index=&messageDisplay=inline&from_ts=1780001531800&to_ts=1780005131800&live=false';
+
+    const response = await apiRewriteHandler.handle(tokensFor(url));
+
+    expect(response.status).toBe(302);
+    expect(locationQuery(response)).toBe(
+      'service:paraform @api:* status:error AND @api:/api/trpc/company.getCompanySlackIds',
+    );
+  });
+
+  test('preserves other params', async () => {
+    const url =
+      'https://app.datadoghq.com/logs?query=#api_no_api:trpc\\/x&cols=host,service&from_ts=1&to_ts=2';
+
+    const location = (await apiRewriteHandler.handle(tokensFor(url))).headers.get('location') ?? '';
+
+    expect(location).toContain('cols=host%2Cservice');
+    expect(location).toContain('from_ts=1');
+    expect(location).toContain('to_ts=2');
+  });
+
+  test('rewrites multiple #api_no_api occurrences', async () => {
+    const url = 'https://app.datadoghq.com/logs?query=#api_no_api:trpc\\/a OR #api_no_api:trpc\\/b';
+
+    const response = await apiRewriteHandler.handle(tokensFor(url));
+
+    expect(locationQuery(response)).toBe('@api:/api/trpc/a OR @api:/api/trpc/b');
+  });
+
+  test('leaves a query without #api_no_api unchanged', async () => {
+    const url = 'https://app.datadoghq.com/logs?query=service:paraform status:error';
+
+    const response = await apiRewriteHandler.handle(tokensFor(url));
+
+    expect(locationQuery(response)).toBe('service:paraform status:error');
+  });
+
+  test('returns an error for non-URL input', async () => {
+    const response = await apiRewriteHandler.handle(['not', 'a', 'url']);
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain('expects a full Datadog logs URL');
+  });
+});

--- a/src/handlers/dd/rewrite/api.ts
+++ b/src/handlers/dd/rewrite/api.ts
@@ -1,0 +1,61 @@
+import { FunctionHandler } from '../../../Handler';
+import { redirect } from '../../../util';
+
+/** Removes Datadog search escapes, e.g. `trpc\/company` -> `trpc/company`. */
+function unescapeDdValue(value: string): string {
+  return value.replace(/\\(.)/g, '$1');
+}
+
+/**
+ * Rewrites every `#api_no_api:<value>` tag facet in a Datadog query into the
+ * `@api:/api/<value>` attribute facet, unescaping the value and prepending the
+ * `/api/` prefix that the `api_no_api` tag omits.
+ *
+ * `<value>` runs to the next whitespace (`\S+`); the `&`-split in the handler
+ * already isolates the query from the rest of the URL's params.
+ */
+function rewriteApiQuery(query: string): string {
+  return query.replace(
+    /#api_no_api:(\S+)/g,
+    (_match, value) => `@api:/api/${unescapeDdValue(value)}`,
+  );
+}
+
+const apiRewriteHandler = new FunctionHandler(
+  'rewrites #api_no_api:<path> to @api:/api/<path> in a Datadog logs URL',
+  (tokens) => {
+    // neh decodes the whole query and splits on spaces, so a pasted Datadog URL
+    // arrives shattered and fully decoded. Rejoin it, then operate on the raw
+    // string: `new URL()` can't be used because a literal `#` (from the
+    // `#api_no_api` tag) is treated as the URL fragment delimiter.
+    const raw = tokens.join(' ').trim();
+
+    const queryStart = raw.indexOf('?');
+    if (!raw.startsWith('http') || queryStart === -1) {
+      return new Response(
+        'dd rw api expects a full Datadog logs URL, e.g. "dd rw api https://app.datadoghq.com/logs?query=...".',
+        { status: 400 },
+      );
+    }
+
+    const base = raw.slice(0, queryStart);
+    const paramStr = raw.slice(queryStart + 1);
+
+    const rebuilt = paramStr
+      .split('&')
+      .map((pair) => {
+        const eq = pair.indexOf('=');
+        const key = eq === -1 ? pair : pair.slice(0, eq);
+        let value = eq === -1 ? '' : pair.slice(eq + 1);
+        if (key === 'query') {
+          value = rewriteApiQuery(value);
+        }
+        return `${key}=${encodeURIComponent(value)}`;
+      })
+      .join('&');
+
+    return redirect(`${base}?${rebuilt}`);
+  },
+);
+
+export default apiRewriteHandler;

--- a/src/handlers/dd/rewrite/index.ts
+++ b/src/handlers/dd/rewrite/index.ts
@@ -1,0 +1,19 @@
+import { CommandHandler, FunctionHandler } from '../../../Handler';
+
+import apiRewriteHandler from './api';
+
+const rw = new CommandHandler();
+
+rw.addHandler('api', apiRewriteHandler);
+
+rw.setNothingHandler(
+  new FunctionHandler(
+    'lists the available Datadog URL rewrites',
+    () =>
+      new Response('Available dd rewrites:\n  api  ' + apiRewriteHandler.doc + '\n', {
+        headers: { 'content-type': 'text/plain;charset=UTF-8' },
+      }),
+  ),
+);
+
+export default rw;

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -9,6 +9,7 @@ import { redirect } from '../util';
 
 import aiHandler from './ai';
 import customPromptHandler from './custom';
+import ddHandler from './dd';
 import dictHandler from './dict';
 import docsHandler from './docs';
 import ghHandler from './gh';
@@ -27,6 +28,7 @@ const neh = new CommandHandler();
 
 // Handlers with their own files
 neh.addHandler('ai', aiHandler);
+neh.addHandler('dd', ddHandler);
 neh.addHandler('dict', dictHandler);
 neh.addHandler('docs', docsHandler);
 neh.addHandler('gh', ghHandler);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -27,6 +27,9 @@ describe('neh', () => {
   // Some test input
   const testCases = [
     '1 + 1',
+    'dd',
+    'dd status:error service:paraform',
+    'dd apm services',
     'drive 2',
     'drive',
     'ip',


### PR DESCRIPTION
## Summary
Adds a comprehensive Datadog (`dd`) command handler that provides quick access to Datadog products including Logs, APM, Database Monitoring (DBM), and RUM, along with a URL rewrite utility for transforming Datadog query syntax.

## Key Changes
- **New `dd` handler** (`src/handlers/dd/index.ts`): Main command handler that routes to various Datadog products
  - Bare `dd` navigates to Logs Live Tail
  - `dd <query>` performs a logs search
  - `dd l/logs` searches logs
  - `dd lt/livetail` navigates to Live Tail
  - `dd apm/a` searches APM traces or navigates to services with `dd apm services`
  - `dd dbm` navigates to Database Monitoring
  - `dd rum` searches RUM explorer

- **Datadog search engine** (`src/handlers/dd/datadog.ts`): Custom search engine implementation that properly handles Datadog's query syntax
  - Uses `encodeURIComponent` for proper encoding of spaces as `%20` and special characters
  - Handles literal `#` characters in queries (e.g., tag facets like `#api_no_api:`) by avoiding URL parsing

- **URL rewrite utility** (`src/handlers/dd/rewrite/`): Transforms Datadog query syntax
  - `dd rw api` rewrites `#api_no_api:<path>` tags to `@api:/api/<path>` attribute facets
  - Unescapes values and prepends the `/api/` prefix
  - Preserves other URL parameters during rewriting

- **Comprehensive test coverage**: Added unit tests for the handler and rewrite functionality, plus integration tests in the main test suite

## Notable Implementation Details
- Custom search engine avoids `new URL()` parsing to prevent `#` characters from being treated as URL fragment delimiters
- Rewrite handler reconstructs URLs from space-split, fully-decoded tokens to handle pasted Datadog URLs correctly
- Nested command structure allows for intuitive subcommands (e.g., `dd apm services`, `dd dbm q`)

https://claude.ai/code/session_01J2FMCdCBCc7nGkPfY7ms8g