### PR TITLE
Fix dd rw api double-encoding pasted Datadog URLs

### DIFF
--- a/src/handlers/dd/rewrite/api.test.ts
+++ b/src/handlers/dd/rewrite/api.test.ts
@@ -1,22 +1,22 @@
 import apiRewriteHandler from './api';
 
-// neh decodes the incoming query and splits it on spaces before a handler sees
-// it, so a pasted Datadog URL arrives as space-split, fully-decoded tokens.
-function tokensFor(decodedUrl: string): string[] {
-  return decodedUrl.split(' ');
+// A pasted Datadog URL reaches the handler as a single token whose `query=`
+// param is still percent-encoded (it survives neh's browser-encode -> decode
+// round trip in its original form).
+function locationOf(response: Response): string {
+  return response.headers.get('location') ?? '';
 }
 
 function locationQuery(response: Response): string {
-  const location = response.headers.get('location') ?? '';
-  return new URL(location).searchParams.get('query') ?? '';
+  return new URL(locationOf(response)).searchParams.get('query') ?? '';
 }
 
 describe('dd rw api handler', () => {
-  test('rewrites #api_no_api to @api:/api/ for the documented example', async () => {
+  test('rewrites #api_no_api (with escaped slashes) to @api:/api/', async () => {
     const url =
-      'https://app.datadoghq.com/logs?query=service:paraform @api:* status:error AND #api_no_api:trpc\\/company.getCompanySlackIds&calculated_fields=&cols=host,service&fromUser=true&index=&messageDisplay=inline&from_ts=1780001531800&to_ts=1780005131800&live=false';
+      'https://app.datadoghq.com/logs?query=service%3Aparaform%20%40api%3A%2A%20status%3Aerror%20AND%20%23api_no_api%3Atrpc%5C%2Fcompany.getCompanySlackIds&cols=host%2Cservice&from_ts=1&to_ts=2';
 
-    const response = await apiRewriteHandler.handle(tokensFor(url));
+    const response = await apiRewriteHandler.handle([url]);
 
     expect(response.status).toBe(302);
     expect(locationQuery(response)).toBe(
@@ -24,31 +24,53 @@ describe('dd rw api handler', () => {
     );
   });
 
-  test('preserves other params', async () => {
+  test('rewrites #api_no_api (with plain slashes) to @api:/api/', async () => {
     const url =
-      'https://app.datadoghq.com/logs?query=#api_no_api:trpc\\/x&cols=host,service&from_ts=1&to_ts=2';
+      'https://app.datadoghq.com/logs?query=service%3Aparaform%20AND%20%23api_no_api%3Acron%2Femails%2Fdetect_bounce_emails&agg_m=count';
 
-    const location = (await apiRewriteHandler.handle(tokensFor(url))).headers.get('location') ?? '';
+    const response = await apiRewriteHandler.handle([url]);
+
+    expect(locationQuery(response)).toBe(
+      'service:paraform AND @api:/api/cron/emails/detect_bounce_emails',
+    );
+  });
+
+  test('preserves other params byte-identically and does not double-encode', async () => {
+    const url =
+      'https://app.datadoghq.com/logs?query=%23api_no_api%3Atrpc%5C%2Fx&cols=host%2Cservice&from_ts=1&to_ts=2';
+
+    const location = locationOf(await apiRewriteHandler.handle([url]));
 
     expect(location).toContain('cols=host%2Cservice');
     expect(location).toContain('from_ts=1');
     expect(location).toContain('to_ts=2');
+    expect(location).not.toContain('%25'); // no double-encoding
   });
 
   test('rewrites multiple #api_no_api occurrences', async () => {
-    const url = 'https://app.datadoghq.com/logs?query=#api_no_api:trpc\\/a OR #api_no_api:trpc\\/b';
+    const url =
+      'https://app.datadoghq.com/logs?query=%23api_no_api%3Atrpc%2Fa%20OR%20%23api_no_api%3Atrpc%2Fb';
 
-    const response = await apiRewriteHandler.handle(tokensFor(url));
+    const response = await apiRewriteHandler.handle([url]);
 
     expect(locationQuery(response)).toBe('@api:/api/trpc/a OR @api:/api/trpc/b');
   });
 
   test('leaves a query without #api_no_api unchanged', async () => {
-    const url = 'https://app.datadoghq.com/logs?query=service:paraform status:error';
+    const url = 'https://app.datadoghq.com/logs?query=service%3Aparaform%20status%3Aerror';
 
-    const response = await apiRewriteHandler.handle(tokensFor(url));
+    const response = await apiRewriteHandler.handle([url]);
 
     expect(locationQuery(response)).toBe('service:paraform status:error');
+  });
+
+  test('falls back to the raw value when the query is not valid percent-encoding', async () => {
+    const url = 'https://app.datadoghq.com/logs?query=foo%';
+
+    const response = await apiRewriteHandler.handle([url]);
+
+    expect(response.status).toBe(302);
+    expect(locationQuery(response)).toBe('foo%');
   });
 
   test('returns an error for non-URL input', async () => {

--- a/src/handlers/dd/rewrite/api.ts
+++ b/src/handlers/dd/rewrite/api.ts
@@ -11,8 +11,8 @@ function unescapeDdValue(value: string): string {
  * `@api:/api/<value>` attribute facet, unescaping the value and prepending the
  * `/api/` prefix that the `api_no_api` tag omits.
  *
- * `<value>` runs to the next whitespace (`\S+`); the `&`-split in the handler
- * already isolates the query from the rest of the URL's params.
+ * Operates on a DECODED query string; `<value>` runs to the next whitespace
+ * (`\S+`).
  */
 function rewriteApiQuery(query: string): string {
   return query.replace(
@@ -24,10 +24,12 @@ function rewriteApiQuery(query: string): string {
 const apiRewriteHandler = new FunctionHandler(
   'rewrites #api_no_api:<path> to @api:/api/<path> in a Datadog logs URL',
   (tokens) => {
-    // neh decodes the whole query and splits on spaces, so a pasted Datadog URL
-    // arrives shattered and fully decoded. Rejoin it, then operate on the raw
-    // string: `new URL()` can't be used because a literal `#` (from the
-    // `#api_no_api` tag) is treated as the URL fragment delimiter.
+    // A pasted Datadog URL survives neh's browser-encode -> decode round trip in
+    // its original form: the whole URL arrives as a single token whose `query=`
+    // param is still percent-encoded (e.g. `%23api_no_api%3A...`). So we split on
+    // the raw `&`/`=` boundaries, then decode just the query value before
+    // rewriting and re-encode it exactly once. Other params are left
+    // byte-identical so we never double-encode them.
     const raw = tokens.join(' ').trim();
 
     const queryStart = raw.indexOf('?');
@@ -45,12 +47,18 @@ const apiRewriteHandler = new FunctionHandler(
       .split('&')
       .map((pair) => {
         const eq = pair.indexOf('=');
-        const key = eq === -1 ? pair : pair.slice(0, eq);
-        let value = eq === -1 ? '' : pair.slice(eq + 1);
-        if (key === 'query') {
-          value = rewriteApiQuery(value);
+        if (eq === -1 || pair.slice(0, eq) !== 'query') {
+          // Leave every non-query param exactly as received.
+          return pair;
         }
-        return `${key}=${encodeURIComponent(value)}`;
+        const rawValue = pair.slice(eq + 1);
+        let decoded: string;
+        try {
+          decoded = decodeURIComponent(rawValue);
+        } catch {
+          decoded = rawValue;
+        }
+        return `query=${encodeURIComponent(rewriteApiQuery(decoded))}`;
       })
       .join('&');
 


### PR DESCRIPTION
## Problem

`dd rw api <datadog-logs-url>` produced a broken, double-encoded URL and never performed the rewrite. For example:

```
dd rw api https://app.datadoghq.com/logs?query=...%23api_no_api%3Acron%2Femails%2Fdetect_bounce_emails&...
```

returned a `query` like `service%253Aparaform%2520...%2523api_no_api%253A...` — every `%` re-encoded to `%25`, and `#api_no_api` left untransformed.

## Root cause

A pasted Datadog URL survives neh's browser-encode → neh-decode round trip in its **original (encoded) form**: the whole URL arrives as a single token whose `query=` param is still percent-encoded (`%23api_no_api%3A…`, `%20`, `%3A`). The handler wrongly assumed the query arrived fully *decoded*, so it:

1. matched `#api_no_api:` against the encoded text `%23api_no_api%3A` — which never matched → no rewrite; and
2. ran `encodeURIComponent` on an already-encoded value → `%3A` → `%253A` (double encoding). It also re-encoded every other param, mangling things like `cols`.

## Fix

In `src/handlers/dd/rewrite/api.ts`:

- **Decode** the `query` value before rewriting, then **re-encode it exactly once**.
- Leave every **other** param byte-identical (no re-encoding).

The rewrite (`#api_no_api:<path>` → `@api:/api/<path>`, unescaping `\/`) now runs on the decoded query and handles both escaped (`%5C%2F`) and plain (`%2F`) slashes.

### Result for the reported URL

```
…?query=service%3Aparaform%20%40api%3A*%20status%3Aerror%20AND%20%40api%3A%2Fapi%2Fcron%2Femails%2Fdetect_bounce_emails&agg_m=count&cols=host%2Cservice&live=true
```

`#api_no_api:cron/emails/detect_bounce_emails` → `@api:/api/cron/emails/detect_bounce_emails`, no double-encoding, other params preserved.

## Tests

Rewrote `src/handlers/dd/rewrite/api.test.ts` to feed realistic percent-encoded URLs (escaped + plain slashes, multiple occurrences, byte-identical param preservation, no `%25` double-encoding, malformed-encoding fallback). 168 tests pass; lint and typecheck clean.

https://claude.ai/code/session_01J2FMCdCBCc7nGkPfY7ms8g

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2FMCdCBCc7nGkPfY7ms8g)_