### PR TITLE
Handle schemeless source URLs in the l handler

### DIFF
--- a/src/handlers/l.test.ts
+++ b/src/handlers/l.test.ts
@@ -79,5 +79,25 @@ describe('l handler', () => {
     test('ignores `s` and port tokens in real host mode', async () => {
       expect(await location('s', '80', 'eliangtan', '/abc')).toBe('https://eliangtan.com/abc');
     });
+
+    test('accepts a schemeless source URL copied from the address bar', async () => {
+      expect(await location('eliangtan.com', 'localhost:3000/abc')).toBe(
+        'https://eliangtan.com/abc',
+      );
+    });
+
+    test('accepts a schemeless source URL with a port but no path', async () => {
+      expect(await location('eliangtan.com', 'localhost:3000')).toBe('https://eliangtan.com');
+    });
+  });
+
+  describe('schemeless source URLs', () => {
+    test('treats a schemeless localhost URL as the path source in localhost mode', async () => {
+      expect(await location('localhost:3000/abc')).toBe('http://localhost:3000/abc');
+    });
+
+    test('treats a schemeless host/path as the path source', async () => {
+      expect(await location('whatever.com/abc')).toBe('http://localhost:3000/abc');
+    });
   });
 });

--- a/src/handlers/l.ts
+++ b/src/handlers/l.ts
@@ -18,10 +18,12 @@ function extractPath(token: Token): string {
   return pathStart === -1 ? '' : rest.slice(pathStart);
 }
 
-// A token is a URL/path (rather than a bare host) if it has a scheme or is an
-// absolute path.
+// A token is a URL/path (rather than a bare target host) if it contains a path
+// or a port. This includes schemeless forms copied from the address bar, where
+// the browser hides the scheme, e.g. `localhost:3000/abc` or `localhost:3000`.
+// A bare host like `eliangtan.com` has neither a "/" nor a ":port".
 function isUrlOrPath(token: Token): boolean {
-  return /^[a-z][a-z0-9+\-.]*:\/\//i.test(token) || token.startsWith('/');
+  return token.includes('/') || /:\d/.test(token);
 }
 
 // Ensures a bare host ends in a valid TLD, appending ".com" if it doesn't.
@@ -55,6 +57,8 @@ function normalizeHost(host: string): string {
 // - `l eliangtan http://localhost:23423/abc`     => https://eliangtan.com/abc
 // - `l www.eliangtan https://localhost:22/abc`   => https://www.eliangtan.com/abc
 // - `l eliang.science https://localhost/abc`     => https://eliang.science/abc
+// - `l eliangtan.com localhost:3000/abc`         => https://eliangtan.com/abc
+//   (the source URL may be schemeless, as copied from the address bar)
 const lHandler = new FunctionHandler(
   'rewrites a URL host; defaults to localhost (e.g. `l https://whatever.com/abc` => http://localhost:3000/abc, `l s 80` => https://localhost:80, `l 5243` => http://localhost:5243), or to a given host over https with `.com` appended if no TLD is present (e.g. `l eliangtan http://localhost:23423/abc` => https://eliangtan.com/abc)',
   (tokens) => {


### PR DESCRIPTION
## Summary
When you copy a URL from the browser's address bar, the scheme is hidden, so the token arrives schemeless — e.g. `localhost:3000/abc`. The `l` handler's classifier only treated a token as a URL/path source when it had a scheme (`://`) or a leading `/`, so a schemeless source URL was misread as a target **host**, breaking the command:

```
l eliangtan.com localhost:3000/abc
```
…previously treated `localhost:3000/abc` as a host and produced garbage. It now correctly produces:
```
https://eliangtan.com/abc
```

## Fix
Classify a token as a URL/path source if it contains a path (`/`) or a port (`:<digits>`), which covers schemeless address-bar forms like `localhost:3000/abc` and `localhost:3000`. A bare target host (`eliangtan.com`, `www.eliangtan`, `eliang.science`) has neither, so the two are still distinguished.

`extractPath()` already handled schemeless host/port/path tokens, so only the classifier needed changing.

## Examples now handled
| Input | Result |
|---|---|
| `l eliangtan.com localhost:3000/abc` | `https://eliangtan.com/abc` |
| `l eliangtan.com localhost:3000` | `https://eliangtan.com` |
| `l localhost:3000/abc` | `http://localhost:3000/abc` |
| `l whatever.com/abc` | `http://localhost:3000/abc` |

All previously supported forms are unchanged.

## Testing
- Added cases for schemeless source URLs in both real-host and localhost modes.
- 185 tests pass; 100% line coverage; typecheck and lint clean.

https://claude.ai/code/session_01AsHUxUFV22pKh43JYAuhWB

---
_Generated by [Claude Code](https://claude.ai/code/session_01AsHUxUFV22pKh43JYAuhWB)_